### PR TITLE
Seal every class possible and fix access modifiers.

### DIFF
--- a/source/AllNode.cs
+++ b/source/AllNode.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class AllNode : RuleNode
+public sealed class AllNode : RuleNode
 {
     override protected bool Load(XElement xelem, bool[] parentSymmetry, Grid grid)
     {

--- a/source/ArrayHelper.cs
+++ b/source/ArrayHelper.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-static class AH
+public static class AH
 {
     public static T[][][] Array3D<T>(int MX, int MY, int MZ, T value)
     {

--- a/source/ConvChain.cs
+++ b/source/ConvChain.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Xml.Linq;
 
-class ConvChainNode : Node
+public sealed class ConvChainNode : Node
 {
     int N;
     double temperature;

--- a/source/Convolution.cs
+++ b/source/Convolution.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class ConvolutionNode : Node
+public sealed class ConvolutionNode : Node
 {
     ConvolutionRule[] rules;
     int[] kernel;
@@ -129,7 +129,7 @@ class ConvolutionNode : Node
         return change;
     }
 
-    class ConvolutionRule
+    public sealed class ConvolutionRule
     {
         public byte input, output;
         public byte[] values;

--- a/source/Field.cs
+++ b/source/Field.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class Field
+public sealed class Field
 {
     public bool recompute, inversed, essential;
     public int zero, substrate;

--- a/source/GUI.cs
+++ b/source/GUI.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-static class GUI
+public static class GUI
 {
     const int S = 7, SMALL = 3, ZSHIFT = 2, LIMIT = 10;
     const int HINDENT = 30, HGAP = 2, HARROW = 10, HLINE = 14;

--- a/source/Graphics.cs
+++ b/source/Graphics.cs
@@ -5,7 +5,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Collections.Generic;
 
-static class Graphics
+public static class Graphics
 {
     public static (int[], int, int, int) LoadBitmap(string filename)
     {
@@ -163,7 +163,7 @@ static class Graphics
     }
 }
 
-class Sprite
+public sealed class Sprite
 {
     public int[] cube;
     public int[][] edges;
@@ -204,7 +204,7 @@ class Sprite
     }
 }
 
-struct Voxel
+public struct Voxel
 {
     public int color;
     public int x, y, z;

--- a/source/Grid.cs
+++ b/source/Grid.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class Grid
+public sealed class Grid
 {
     public byte[] state;
     public bool[] mask;

--- a/source/Helper.cs
+++ b/source/Helper.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-static class Helper
+public static class Helper
 {
     public static (byte[], int) Ords(this int[] data, List<int> uniques = null)
     {
@@ -86,7 +86,7 @@ static class Helper
     }
 }
 
-static class RandomHelper
+public static class RandomHelper
 {
     public static T Random<T>(this List<T> list, Random random) => list[random.Next(list.Count)];
     

--- a/source/Interpreter.cs
+++ b/source/Interpreter.cs
@@ -4,7 +4,7 @@ using System;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class Interpreter
+public sealed class Interpreter
 {
     public Branch root, current;
     public Grid grid;

--- a/source/Map.cs
+++ b/source/Map.cs
@@ -3,7 +3,7 @@
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class MapNode : Branch
+public sealed class MapNode : Branch
 {
     Grid newgrid;
     Rule[] rules;

--- a/source/Node.cs
+++ b/source/Node.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using System.Xml.Linq;
 
-abstract class Node
+public abstract class Node
 {
     abstract protected bool Load(XElement xelem, bool[] symmetry, Grid grid);
     abstract public void Reset();
@@ -48,7 +48,7 @@ abstract class Node
     protected static string[] nodenames = new string[] { "one", "all", "prl", "markov", "sequence", "path", "map", "convolution", "convchain", "wfc" };
 }
 
-abstract class Branch : Node
+public abstract class Branch : Node
 {
     public Branch parent;
     public Node[] nodes;
@@ -96,8 +96,8 @@ abstract class Branch : Node
     }
 }
 
-class SequenceNode : Branch { }
-class MarkovNode : Branch
+public sealed class SequenceNode : Branch { }
+public sealed class MarkovNode : Branch
 {
     public MarkovNode() { }
     public MarkovNode(Node child, Interpreter ip) { nodes = new Node[] { child }; this.ip = ip; grid = ip.grid; }

--- a/source/Observation.cs
+++ b/source/Observation.cs
@@ -3,7 +3,7 @@
 using System.Linq;
 using System.Collections.Generic;
 
-class Observation
+public sealed class Observation
 {
     readonly byte from;
     readonly int to;

--- a/source/OneNode.cs
+++ b/source/OneNode.cs
@@ -4,7 +4,7 @@ using System;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class OneNode : RuleNode
+public sealed class OneNode : RuleNode
 {
     override protected bool Load(XElement xelem, bool[] parentSymmetry, Grid grid)
     {

--- a/source/OverlapModel.cs
+++ b/source/OverlapModel.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class OverlapNode : WFCNode
+public sealed class OverlapNode : WFCNode
 {
     byte[][] patterns;
 

--- a/source/ParallelNode.cs
+++ b/source/ParallelNode.cs
@@ -2,7 +2,7 @@
 
 using System.Xml.Linq;
 
-class ParallelNode : RuleNode
+public sealed class ParallelNode : RuleNode
 {
     byte[] newstate;
 

--- a/source/Path.cs
+++ b/source/Path.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class PathNode : Node
+public sealed class PathNode : Node
 {
     public int start, finish, substrate;
     public byte value;

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -6,9 +6,9 @@ using System.Xml.Linq;
 using System.Diagnostics;
 using System.Collections.Generic;
 
-static class Program
+public static class Program
 {
-    static void Main()
+    public static void Main()
     {
         Stopwatch sw = Stopwatch.StartNew();
         var folder = System.IO.Directory.CreateDirectory("output");

--- a/source/Rule.cs
+++ b/source/Rule.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class Rule
+public sealed class Rule
 {
     public int IMX, IMY, IMZ, OMX, OMY, OMZ;
     public int[] input;

--- a/source/RuleNode.cs
+++ b/source/RuleNode.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-abstract class RuleNode : Node
+public abstract class RuleNode : Node
 {
     public Rule[] rules;
     public int counter, steps;

--- a/source/Search.cs
+++ b/source/Search.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-static class Search
+public static class Search
 {
     public static byte[][] Run(byte[] present, int[] future, Rule[] rules, int MX, int MY, int MZ, int C, bool all, int limit, double depthCoefficient, int seed)
     {
@@ -250,7 +250,7 @@ static class Search
     }
 }
 
-class Board
+public sealed class Board
 {
     public byte[] state;
     public int parentIndex, depth, backwardEstimate, forwardEstimate;
@@ -278,7 +278,7 @@ class Board
     }
 }
 
-class StateComparer : IEqualityComparer<byte[]>
+public sealed class StateComparer : IEqualityComparer<byte[]>
 {
     public bool Equals(byte[] a, byte[] b)
     {

--- a/source/SymmetryHelper.cs
+++ b/source/SymmetryHelper.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-static class SymmetryHelper
+public static class SymmetryHelper
 {
     public static Dictionary<string, bool[]> squareSubgroups = new()
     {

--- a/source/TileModel.cs
+++ b/source/TileModel.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-class TileNode : WFCNode
+public sealed class TileNode : WFCNode
 {
     List<byte[]> tiledata;
 

--- a/source/VoxHelper.cs
+++ b/source/VoxHelper.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Text;
 using System.Collections.Generic;
 
-static class VoxHelper
+public static class VoxHelper
 {
     public static (int[], int, int, int) LoadVox(string filename)
     {

--- a/source/WaveFunctionCollapse.cs
+++ b/source/WaveFunctionCollapse.cs
@@ -4,7 +4,7 @@ using System;
 using System.Xml.Linq;
 using System.Collections.Generic;
 
-abstract class WFCNode : Branch
+public abstract class WFCNode : Branch
 {
     protected Wave wave;
     protected int[][][] propagator;
@@ -258,7 +258,7 @@ abstract class WFCNode : Branch
     protected static int[] DZ = { 0, 0, 0, 0, 1, -1 };
 }
 
-class Wave
+public sealed class Wave
 {
     public bool[][] data;
     public int[][][] compatible;

--- a/source/XMLHelper.cs
+++ b/source/XMLHelper.cs
@@ -6,7 +6,7 @@ using System.Xml.Linq;
 using System.ComponentModel;
 using System.Collections.Generic;
 
-static class XMLHelper
+public static class XMLHelper
 {
     public static T Get<T>(this XElement xelem, string attribute)
     {


### PR DESCRIPTION
# About this PR
Sealed classes have (mostly minor, but present, due to allowing the JIT to directly call functions on a class instead of doing vtable lookups) performance improvements over the default "virtual" (can be derived from & constructable) class. This'll mostly be important for classes that don't see their abstract version used much, the improvement for Nodes and similar is more minor, but present as they can avoid vtable lookups when a function for said node calls another function on said node.

Also fixed access while at it, to ease potentially making this into a library in the future. It'd be very nice to be able to easily use this code in other projects as a nuget package or similar.