### PR TITLE
Replace System.Drawing with SixLabors.ImageSharp

### DIFF
--- a/MarkovJunior.csproj
+++ b/MarkovJunior.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/source/Graphics.cs
+++ b/source/Graphics.cs
@@ -12,14 +12,14 @@ static class Graphics
     {
         try
         {
-            var image = Image.Load<Argb32>(filename);
+            var image = Image.Load<Bgra32>(filename);
             int width = image.Width, height = image.Height;
             var result = new int[width * height];
             for (var j = 0; j < height; j += 1)
             {
                 for (var i = 0; i < width; i += 1)
                 {
-                    result[j * width + i] = unchecked((int) BinaryPrimitives.ReverseEndianness(image[i, j].Argb));
+                    result[j * width + i] = unchecked((int) image[i, j].Bgra);
                 }
             }
 
@@ -34,13 +34,16 @@ static class Graphics
 
     public static void SaveBitmap(int[] data, int width, int height, string filename)
     {
-        var formattedData = new Argb32[data.Length];
+        var formattedData = new Bgra32[data.Length];
         for (var i = 0; i < data.Length; i += 1)
         {
-            formattedData[i] = new Argb32(BinaryPrimitives.ReverseEndianness(unchecked((uint) data[i])));
+            formattedData[i] = new Bgra32
+            {
+                Bgra = unchecked((uint) data[i])
+            };
         }
 
-        var image = Image.WrapMemory(Configuration.Default, new Memory<Argb32>(formattedData), width, height);
+        var image = Image.WrapMemory(Configuration.Default, new Memory<Bgra32>(formattedData), width, height);
         image.SaveAsPng(filename);
         image.Dispose();
     }

--- a/source/Graphics.cs
+++ b/source/Graphics.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) 2022 Maxim Gumin, The MIT License (MIT)
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -13,12 +14,12 @@ static class Graphics
         {
             var image = Image.Load<Argb32>(filename);
             int width = image.Width, height = image.Height;
-            int[] result = new int[width * height];
+            var result = new int[width * height];
             for (var j = 0; j < height; j += 1)
             {
                 for (var i = 0; i < width; i += 1)
                 {
-                    result[j * width + i] = unchecked((int) LeReverseBytes(image[i, j].Argb));
+                    result[j * width + i] = unchecked((int) BinaryPrimitives.ReverseEndianness(image[i, j].Argb));
                 }
             }
 
@@ -30,25 +31,13 @@ static class Graphics
             return (null, -1, -1, -1);
         }
     }
-    
-    static UInt32 ReverseBytes(UInt32 value)
-    {
-        return (value & 0x000000FFU) << 24 | (value & 0x0000FF00U) << 8 |
-               (value & 0x00FF0000U) >> 8 | (value & 0xFF000000U) >> 24;
-    }
-
-    static UInt32 LeReverseBytes(UInt32 value)
-    {
-        return BitConverter.IsLittleEndian ? ReverseBytes(value) : value;
-    }
-
 
     public static void SaveBitmap(int[] data, int width, int height, string filename)
     {
-        Argb32[] formattedData = new Argb32[data.Length];
-        for (int i = 0; i < data.Length; i += 1)
+        var formattedData = new Argb32[data.Length];
+        for (var i = 0; i < data.Length; i += 1)
         {
-            formattedData[i] = new Argb32(LeReverseBytes(unchecked((uint) data[i])));
+            formattedData[i] = new Argb32(BinaryPrimitives.ReverseEndianness(unchecked((uint) data[i])));
         }
 
         var image = Image.WrapMemory(Configuration.Default, new Memory<Argb32>(formattedData), width, height);


### PR DESCRIPTION
Microsoft recommends switching to a third party library for cross platform image manipulation:
https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only

I implemented the Save/Load bitmap functions with `SixLabors.ImageSharp`, all examples seem to work on my system now.

closes #3 

Feel free to close this if you want to take a different approach, I was mostly interested in getting it to work on my system.